### PR TITLE
Export header files and information about include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ endif(BUILD_TESTS)
 
 add_compile_options(-fPIC -Wall -Wextra -Wpedantic)
 
-include_directories(${PROJECT_SOURCE_DIR}/include)
+include(GNUInstallDirs)
 
 add_subdirectory(python)
 add_subdirectory(source)
@@ -45,17 +45,12 @@ if(BUILD_TESTS)
 endif(BUILD_TESTS)
 
 set(installable_libs angcorrRejectionSampler angular_correlation alphavCoefficient avCoefficient cascadeRejectionSampler euler_angle_rotation fCoefficient kappa_coefficient sphereRejectionSampler state transition uvCoefficient w_dir_dir w_gamma_gamma w_pol_dir)
-install(TARGETS ${installable_libs}
-        DESTINATION lib
-        EXPORT ALPACA
+install(
+    TARGETS ${installable_libs}
+    EXPORT ALPACA
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
-
-set(_ALPACA_HEADERS AlphavCoefficient.hh AngCorrRejectionSampler.hh AngularCorrelation.hh AvCoefficient.hh CascadeRejectionSampler.hh EulerAngleRotation.hh KappaCoefficient.hh SphereRejectionSampler.hh State.hh StringRepresentable.hh Transition.hh UvCoefficient.hh W_gamma_gamma.hh W_dir_dir.hh W_pol_dir.hh)
-set(ALPACA_HEADERS "")
-foreach(header ${_ALPACA_HEADERS})
-        list(APPEND ALPACA_HEADERS "include/${header}")
-endforeach(header)
-install(FILES ${ALPACA_HEADERS} DESTINATION include)
 
 install(EXPORT ALPACA
         FILE alpaca-config.cmake

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -15,55 +15,91 @@
 #
 #    Copyright (C) 2021 Udo Friman-Gayer
 
-include_directories(${PROJECT_SOURCE_DIR}/include/)
+#include_directories(${PROJECT_SOURCE_DIR}/include/)
 
 add_library(fCoefficient FCoefficient.cc)
 target_link_libraries(fCoefficient ${GSL_LIBRARIES})
+target_include_directories(fCoefficient PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(fCoefficient PROPERTIES PUBLIC_HEADER include/FCoefficient.hh)
 
 add_library(avCoefficient AvCoefficient.cc)
 target_link_libraries(avCoefficient fCoefficient)
+target_include_directories(avCoefficient PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(avCoefficient PROPERTIES PUBLIC_HEADER include/AvCoefficient.hh)
 
 add_library(state State.cc)
+target_include_directories(state PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(state PROPERTIES PUBLIC_HEADER include/State.hh)
 
 add_library(transition Transition.cc)
 target_link_libraries(transition state)
+target_include_directories(transition PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(transition PROPERTIES PUBLIC_HEADER include/Transition.hh)
 
 add_library(w_gamma_gamma W_gamma_gamma.cc)
+target_include_directories(w_gamma_gamma PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(w_gamma_gamma PROPERTIES PUBLIC_HEADER include/W_gamma_gamma.hh)
 
 add_library(w_dir_dir W_dir_dir.cc)
 target_link_libraries(w_dir_dir avCoefficient uvCoefficient)
+target_include_directories(w_dir_dir PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(w_dir_dir PROPERTIES PUBLIC_HEADER include/W_dir_dir.hh)
 
 add_library(kappa_coefficient KappaCoefficient.cc)
 target_link_libraries(kappa_coefficient ${GSL_LIBRARIES})
+target_include_directories(kappa_coefficient PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(kappa_coefficient PROPERTIES PUBLIC_HEADER include/KappaCoefficient.hh)
 
 add_library(alphavCoefficient AlphavCoefficient.cc)
 target_link_libraries(alphavCoefficient fCoefficient kappa_coefficient)
+target_include_directories(alphavCoefficient PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(alphavCoefficient PROPERTIES PUBLIC_HEADER include/AlphavCoefficient.hh)
 
 add_library(evCoefficient EvCoefficient.cc)
 target_link_libraries(evCoefficient fCoefficient)
+target_include_directories(evCoefficient PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(evCoefficient PROPERTIES PUBLIC_HEADER include/EvCoefficient.hh)
 
 add_library(uvCoefficient UvCoefficient.cc)
 target_link_libraries(uvCoefficient ${GSL_LIBRARIES})
+target_include_directories(uvCoefficient PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(uvCoefficient PROPERTIES PUBLIC_HEADER include/UvCoefficient.hh)
 
 add_library(w_pol_dir W_pol_dir.cc)
 target_link_libraries(w_pol_dir alphavCoefficient avCoefficient w_dir_dir)
+target_include_directories(w_pol_dir PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(w_pol_dir PROPERTIES PUBLIC_HEADER include/W_pol_dir.hh)
 
 add_library(angular_correlation SHARED AngularCorrelation.cc)
-target_link_libraries(angular_correlation euler_angle_rotation state transition w_dir_dir w_pol_dir)
+target_link_libraries(angular_correlation PUBLIC euler_angle_rotation state transition w_dir_dir w_pol_dir)
+target_include_directories(angular_correlation PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(angular_correlation PROPERTIES PUBLIC_HEADER include/AngularCorrelation.hh)
 
 add_library(euler_angle_rotation EulerAngleRotation.cc)
+target_include_directories(euler_angle_rotation PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(euler_angle_rotation PROPERTIES PUBLIC_HEADER include/EulerAngleRotation.hh)
 
 add_library(spherePointSampler SpherePointSampler.cc)
 target_link_libraries(spherePointSampler ${GSL_LIBRARIES})
+target_include_directories(spherePointSampler PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(spherePointSampler PROPERTIES PUBLIC_HEADER include/SpherePointSampler.hh)
 
 add_library(sphereIntegrator SphereIntegrator.cc)
 target_link_libraries(sphereIntegrator spherePointSampler)
+target_include_directories(sphereIntegrator PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(sphereIntegrator PROPERTIES PUBLIC_HEADER include/SphereIntegrator.hh)
 
 add_library(sphereRejectionSampler SphereRejectionSampler.cc)
 target_link_libraries(sphereRejectionSampler euler_angle_rotation)
+target_include_directories(sphereRejectionSampler PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(sphereRejectionSampler PROPERTIES PUBLIC_HEADER include/SphereRejectionSampler.hh)
 
 add_library(angcorrRejectionSampler AngCorrRejectionSampler.cc)
 target_link_libraries(angcorrRejectionSampler sphereRejectionSampler angular_correlation)
+target_include_directories(angcorrRejectionSampler PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(angcorrRejectionSampler PROPERTIES PUBLIC_HEADER include/AngCorrRejectionSampler.hh)
 
 add_library(cascadeRejectionSampler CascadeRejectionSampler.cc)
 target_link_libraries(cascadeRejectionSampler angular_correlation angcorrRejectionSampler)
+target_include_directories(cascadeRejectionSampler PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+set_target_properties(cascadeRejectionSampler PROPERTIES PUBLIC_HEADER include/CascadeRejectionSampler.hh)


### PR DESCRIPTION
This fixes a problem where the library headers were not found by external users of the library, because the generated CMake targets did not know about them.